### PR TITLE
fix(sync): fix isLatest handling when DB is not empty

### DIFF
--- a/src/lib/collect-items.ts
+++ b/src/lib/collect-items.ts
@@ -79,6 +79,9 @@ const setContainerRegistry = (ctx: SyncCtx, manifest: Manifest) => {
 }
 
 const setIsLatest = (manifests: Manifest[]) => {
+  // This is needed to unset "isLatest" to all but the latest release
+  manifests.forEach((manifest) => { set(manifest, 'isLatest', null) })
+
   const latestManifest = findLatestRelease(manifests)
 
   if (latestManifest) {

--- a/src/lib/sync-items.ts
+++ b/src/lib/sync-items.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { unset } from 'lodash-es'
 import type { Collection, Filter, UpdateFilter, WithId } from 'mongodb'
 
 import { uploadImage, uploadSupportedByImage } from './assets'
@@ -37,6 +38,9 @@ const insertNewManifest = async (ctx: SyncCtx, itemsCollection: Collection<DbIte
       createdAt: new Date(),
       creatorId: CREATOR_ID,
     }
+
+    // This is needed to avoid having "isLatest" set to "null" (just for aesthetics)
+    if (newDoc.isLatest !== true) { unset(newDoc, 'isLatest') }
 
     const imageData = await uploadImage(ctx, manifestAbsPath, manifest)
     if (imageData !== null) { newDoc.image = imageData }
@@ -96,7 +100,7 @@ const applyNewManifestToExistingItem = async (ctx: SyncCtx, itemsCollection: Col
   ctx.logger.debug({ filter }, 'Patching existing item')
 
   const setPayload: UpdateFilter<DbItem>['$set'] = {}
-  const unsetPayload: UpdateFilter<DbItem>['$unset'] = {}
+  const unsetPayload: UpdateFilter<DbItem>['$unset'] = { pippo: true }
 
   try {
     const imageData = await uploadImage(ctx, manifestAbsPath, manifest)

--- a/src/lib/sync-items.ts
+++ b/src/lib/sync-items.ts
@@ -100,7 +100,7 @@ const applyNewManifestToExistingItem = async (ctx: SyncCtx, itemsCollection: Col
   ctx.logger.debug({ filter }, 'Patching existing item')
 
   const setPayload: UpdateFilter<DbItem>['$set'] = {}
-  const unsetPayload: UpdateFilter<DbItem>['$unset'] = { pippo: true }
+  const unsetPayload: UpdateFilter<DbItem>['$unset'] = {}
 
   try {
     const imageData = await uploadImage(ctx, manifestAbsPath, manifest)


### PR DESCRIPTION
### Description

When running the script on a DB already populated with items, items that are superseded by a new version would not lose the `isLatest` property.

### Checklist

- [x] Changes are covered by tests.
- [x] Any new `.js` or `.ts` file includes the Apache 2.0 License disclaimer heading.
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#work-with-the-sync-script).
