### PR TITLE
feat(build): set `containerPorts` property as required in items manifests

### DIFF
--- a/items/applications/manifest.schema.json
+++ b/items/applications/manifest.schema.json
@@ -960,6 +960,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "type": "object"
         },
         "endpoints": {
@@ -1851,6 +1852,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "type": "object"
         },
         "listeners": {
@@ -4687,6 +4689,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "minProperties": 1,
           "type": "object"
         },

--- a/items/applications/manifest.schema.json
+++ b/items/applications/manifest.schema.json
@@ -2359,7 +2359,8 @@
                         },
                         "required": [
                           "name",
-                          "dockerImage"
+                          "dockerImage",
+                          "containerPorts"
                         ],
                         "type": "object"
                       },
@@ -3087,7 +3088,8 @@
                   "required": [
                     "name",
                     "type",
-                    "dockerImage"
+                    "dockerImage",
+                    "containerPorts"
                   ],
                   "type": "object"
                 },
@@ -3891,7 +3893,8 @@
                   "required": [
                     "name",
                     "type",
-                    "archiveUrl"
+                    "archiveUrl",
+                    "containerPorts"
                   ],
                   "type": "object"
                 },
@@ -4695,7 +4698,8 @@
                   "required": [
                     "name",
                     "type",
-                    "archiveUrl"
+                    "archiveUrl",
+                    "containerPorts"
                   ],
                   "type": "object"
                 }

--- a/items/applications/manifest.schema.json
+++ b/items/applications/manifest.schema.json
@@ -960,7 +960,6 @@
               ]
             }
           },
-          "additionalProperties": false,
           "type": "object"
         },
         "endpoints": {
@@ -1852,7 +1851,6 @@
               ]
             }
           },
-          "additionalProperties": false,
           "type": "object"
         },
         "listeners": {
@@ -4689,7 +4687,6 @@
               ]
             }
           },
-          "additionalProperties": false,
           "minProperties": 1,
           "type": "object"
         },

--- a/items/applications/manifest.schema.json
+++ b/items/applications/manifest.schema.json
@@ -545,6 +545,27 @@
                       "pattern": "(^[\\w-]+$)",
                       "type": "string"
                     },
+                    "defaultPipeline": {
+                      "anyOf": [
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": true
+                          }
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "deprecated": true
+                    },
+                    "defaultSource": {
+                      "maxLength": 80,
+                      "pattern": "(^[\\w-]+$)",
+                      "type": "string",
+                      "deprecated": true
+                    },
                     "description": {
                       "type": "string"
                     },
@@ -952,14 +973,14 @@
                   "required": [
                     "type",
                     "defaultName",
-                    "internalEndpoints",
-                    "startingCollection"
+                    "internalEndpoints"
                   ],
                   "type": "object"
                 }
               ]
             }
           },
+          "additionalProperties": false,
           "type": "object"
         },
         "endpoints": {
@@ -1851,6 +1872,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "type": "object"
         },
         "listeners": {
@@ -3052,11 +3074,6 @@
                       "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "type": "string"
                     },
-                    "repositoryUrl": {
-                      "format": "uri-reference",
-                      "type": "string",
-                      "deprecated": true
-                    },
                     "tags": {
                       "items": {
                         "type": "string"
@@ -3733,6 +3750,10 @@
                     "description": {
                       "type": "string"
                     },
+                    "dockerImage": {
+                      "pattern": "^(?:[a-z0-9.\\-\\/:]+\\/)?([\\w.}{\\-\\/]+)(:[\\w.}{\\-]+)?$",
+                      "type": "string"
+                    },
                     "mapEnvVarToMountPath": {
                       "type": "object",
                       "additionalProperties": {
@@ -3862,11 +3883,6 @@
                         }
                       },
                       "type": "object"
-                    },
-                    "repositoryUrl": {
-                      "format": "uri-reference",
-                      "type": "string",
-                      "deprecated": true
                     },
                     "type": {
                       "const": "example"
@@ -4538,6 +4554,10 @@
                     "description": {
                       "type": "string"
                     },
+                    "dockerImage": {
+                      "pattern": "^(?:[a-z0-9.\\-\\/:]+\\/)?([\\w.}{\\-\\/]+)(:[\\w.}{\\-]+)?$",
+                      "type": "string"
+                    },
                     "mapEnvVarToMountPath": {
                       "type": "object",
                       "additionalProperties": {
@@ -4668,11 +4688,6 @@
                       },
                       "type": "object"
                     },
-                    "repositoryUrl": {
-                      "format": "uri-reference",
-                      "type": "string",
-                      "deprecated": true
-                    },
                     "type": {
                       "const": "template"
                     }
@@ -4687,6 +4702,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "minProperties": 1,
           "type": "object"
         },

--- a/items/examples/manifest.schema.json
+++ b/items/examples/manifest.schema.json
@@ -918,13 +918,11 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl",
-                "containerPorts"
+                "archiveUrl"
               ],
               "type": "object"
             }
           },
-          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/examples/manifest.schema.json
+++ b/items/examples/manifest.schema.json
@@ -917,7 +917,8 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl"
+                "archiveUrl",
+                "containerPorts"
               ],
               "type": "object"
             }

--- a/items/examples/manifest.schema.json
+++ b/items/examples/manifest.schema.json
@@ -776,6 +776,10 @@
                 "description": {
                   "type": "string"
                 },
+                "dockerImage": {
+                  "pattern": "^(?:[a-z0-9.\\-\\/:]+\\/)?([\\w.}{\\-\\/]+)(:[\\w.}{\\-]+)?$",
+                  "type": "string"
+                },
                 "mapEnvVarToMountPath": {
                   "type": "object",
                   "additionalProperties": {
@@ -906,11 +910,6 @@
                   },
                   "type": "object"
                 },
-                "repositoryUrl": {
-                  "format": "uri-reference",
-                  "type": "string",
-                  "deprecated": true
-                },
                 "type": {
                   "const": "example"
                 }
@@ -923,6 +922,7 @@
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/examples/manifest.schema.json
+++ b/items/examples/manifest.schema.json
@@ -918,11 +918,13 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl"
+                "archiveUrl",
+                "containerPorts"
               ],
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/plugins/manifest.schema.json
+++ b/items/plugins/manifest.schema.json
@@ -1311,11 +1311,6 @@
                   "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                   "type": "string"
                 },
-                "repositoryUrl": {
-                  "format": "uri-reference",
-                  "type": "string",
-                  "deprecated": true
-                },
                 "tags": {
                   "items": {
                     "type": "string"
@@ -1334,6 +1329,7 @@
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/plugins/manifest.schema.json
+++ b/items/plugins/manifest.schema.json
@@ -1329,13 +1329,11 @@
               "required": [
                 "name",
                 "type",
-                "dockerImage",
-                "containerPorts"
+                "dockerImage"
               ],
               "type": "object"
             }
           },
-          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/plugins/manifest.schema.json
+++ b/items/plugins/manifest.schema.json
@@ -1329,11 +1329,13 @@
               "required": [
                 "name",
                 "type",
-                "dockerImage"
+                "dockerImage",
+                "containerPorts"
               ],
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/plugins/manifest.schema.json
+++ b/items/plugins/manifest.schema.json
@@ -596,7 +596,8 @@
                     },
                     "required": [
                       "name",
-                      "dockerImage"
+                      "dockerImage",
+                      "containerPorts"
                     ],
                     "type": "object"
                   },
@@ -1324,7 +1325,8 @@
               "required": [
                 "name",
                 "type",
-                "dockerImage"
+                "dockerImage",
+                "containerPorts"
               ],
               "type": "object"
             }

--- a/items/proxies/manifest.schema.json
+++ b/items/proxies/manifest.schema.json
@@ -196,6 +196,7 @@
               ]
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/proxies/manifest.schema.json
+++ b/items/proxies/manifest.schema.json
@@ -196,7 +196,6 @@
               ]
             }
           },
-          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/sidecars/manifest.schema.json
+++ b/items/sidecars/manifest.schema.json
@@ -698,7 +698,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "containerPorts"
       ],
       "type": "object"
     },

--- a/items/templates/manifest.schema.json
+++ b/items/templates/manifest.schema.json
@@ -918,13 +918,11 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl",
-                "containerPorts"
+                "archiveUrl"
               ],
               "type": "object"
             }
           },
-          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/templates/manifest.schema.json
+++ b/items/templates/manifest.schema.json
@@ -917,7 +917,8 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl"
+                "archiveUrl",
+                "containerPorts"
               ],
               "type": "object"
             }

--- a/items/templates/manifest.schema.json
+++ b/items/templates/manifest.schema.json
@@ -918,11 +918,13 @@
               "required": [
                 "name",
                 "type",
-                "archiveUrl"
+                "archiveUrl",
+                "containerPorts"
               ],
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/items/templates/manifest.schema.json
+++ b/items/templates/manifest.schema.json
@@ -776,6 +776,10 @@
                 "description": {
                   "type": "string"
                 },
+                "dockerImage": {
+                  "pattern": "^(?:[a-z0-9.\\-\\/:]+\\/)?([\\w.}{\\-\\/]+)(:[\\w.}{\\-]+)?$",
+                  "type": "string"
+                },
                 "mapEnvVarToMountPath": {
                   "type": "object",
                   "additionalProperties": {
@@ -906,11 +910,6 @@
                   },
                   "type": "object"
                 },
-                "repositoryUrl": {
-                  "format": "uri-reference",
-                  "type": "string",
-                  "deprecated": true
-                },
                 "type": {
                   "const": "template"
                 }
@@ -923,6 +922,7 @@
               "type": "object"
             }
           },
+          "additionalProperties": false,
           "type": "object"
         }
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint-visitor-keys": "^4.2.0",
     "file-type": "^20.4.1",
     "json-schema-to-ts": "^3.1.1",
+    "jsonpath-plus": "^10.3.0",
     "listr2": "^8.2.5",
     "lodash-es": "^4.17.21",
     "nock": "^14.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,6 +745,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsep-plugin/assignment@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@jsep-plugin/assignment@npm:1.3.0"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 10/0c93b703d84af95b4be9fb6c23fbdbe7c7b6985b41c98fd10386cd54686ed1eb751cb39f5d54abcb621e4da2a0900a3b2a852e5bf7f2d322b756db3b22e42a45
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@jsep-plugin/regex@npm:1.0.4"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 10/0ea6ba81f03955972b762fd9fbc8e3fd7e1c1c12e52ce3d4366e23c0a63c8bff8528687b8b3d8f641cf9f626f8bf5a7841efcd31a2489fe967e1900e5738ee3a
+  languageName: node
+  linkType: hard
+
 "@mia-platform/console-types@npm:^0.33.4":
   version: 0.33.4
   resolution: "@mia-platform/console-types@npm:0.33.4"
@@ -4047,6 +4065,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsep@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jsep@npm:1.4.0"
+  checksum: 10/935824fe6ac28fcff3cd13878f508f99f6c13e7f0f53ec9fca0d3db465e6dd15f8af030bcdc75a38b07c78359c656647435923a26aceb91607027021f00c17f2
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:^3.0.2":
   version: 3.1.0
   resolution: "jsesc@npm:3.1.0"
@@ -4129,6 +4154,20 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 10/a78d812dbbd5642c4f637dd130954acfd231b074965871c3e28a5bbd571f099d623ecf9161f1960c4ddf68e0cc98dee8bebfdb94a71ad4551f85a1afc94b63f6
+  languageName: node
+  linkType: hard
+
+"jsonpath-plus@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "jsonpath-plus@npm:10.3.0"
+  dependencies:
+    "@jsep-plugin/assignment": "npm:^1.3.0"
+    "@jsep-plugin/regex": "npm:^1.0.4"
+    jsep: "npm:^1.4.0"
+  bin:
+    jsonpath: bin/jsonpath-cli.js
+    jsonpath-plus: bin/jsonpath-cli.js
+  checksum: 10/082302334414c7c5ab0cc8239563118f7f14bb2949d001b009f436491d00f94a7a293eed3eaf61ffdaf72f6fda9d25198a4280c4f68a4c403154ca7ed2bd0dc9
   languageName: node
   linkType: hard
 
@@ -5016,6 +5055,7 @@ __metadata:
     file-type: "npm:^20.4.1"
     json-diff: "npm:^1.0.6"
     json-schema-to-ts: "npm:^3.1.1"
+    jsonpath-plus: "npm:^10.3.0"
     listr2: "npm:^8.2.5"
     lodash-es: "npm:^4.17.21"
     mongodb: "npm:^6.15.0"


### PR DESCRIPTION
### Description

This PR adds a step to the items manifests building process to set the `containerPorts` property as required in objects with it.

### Checklist

- [x] Changes are covered by tests.
- [x] Any new `.js` or `.ts` file includes the Apache 2.0 License disclaimer heading.
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#conventions).
