### PR TITLE
feat(catalog): add version 5.0.3 to plugin api-gateway

### DIFF
--- a/items/plugin/api-gateway/versions/5.0.3.json
+++ b/items/plugin/api-gateway/versions/5.0.3.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "../../manifest.schema.json",
+  "categoryId": "orchestrators",
+  "description": "Use this service to route requests to the correct service and verify the need of authentication",
+  "documentation": {
+    "type": "externalLink",
+    "url": "https://docs.mia-platform.eu/docs/runtime_suite/api-gateway/overview"
+  },
+  "image": {
+    "localPath": "../assets/api-gateway_logo_20250410.png"
+  },
+  "itemId": "api-gateway",
+  "name": "Nginx API Gateway",
+  "publishOnMiaDocumentation": true,
+  "repositoryUrl": "https://git.tools.mia-platform.eu/platform/core/api-gateway",
+  "resources": {
+    "services": {
+      "nginx-api-gateway": {
+        "type": "plugin",
+        "name": "nginx-api-gateway",
+        "description": "Use this service to route requests to the correct service and verify the need of authentication",
+        "dockerImage": "nexus.mia-platform.eu/core/api-gateway:5.0.3",
+        "componentId": "api-gateway",
+        "defaultEnvironmentVariables": [],
+        "defaultResources": {
+          "memoryLimits": {
+            "max": "25Mi",
+            "min": "5Mi"
+          },
+          "cpuLimits": {
+            "min": "10m"
+          }
+        },
+        "defaultProbes": {
+          "liveness": {
+            "port": "frontend",
+            "path": "/healthz",
+            "initialDelaySeconds": 15,
+            "periodSeconds": 20
+          },
+          "readiness": {
+            "port": "frontend",
+            "path": "/healthz",
+            "initialDelaySeconds": 5,
+            "periodSeconds": 10
+          }
+        },
+        "defaultLogParser": "mia-nginx",
+        "defaultDocumentationPath": "",
+        "defaultConfigMaps": [
+          {
+            "name": "api-gateway-server",
+            "mountPath": "/etc/nginx/conf.d",
+            "files": [],
+            "viewAsReadOnly": true
+          },
+          {
+            "name": "api-gateway-platform",
+            "mountPath": "/etc/nginx/platform.d",
+            "files": [],
+            "viewAsReadOnly": true
+          },
+          {
+            "name": "api-gateway-customization",
+            "mountPath": "/etc/nginx/customization.d",
+            "files": [],
+            "viewAsReadOnly": true,
+            "link": {
+              "targetSection": "endpoints"
+            }
+          },
+          {
+            "name": "api-gateway-backoffice",
+            "mountPath": "/etc/nginx/backoffice.d",
+            "files": [],
+            "viewAsReadOnly": true
+          }
+        ],
+        "containerPorts": [
+          {
+            "name": "frontend",
+            "from": 8080,
+            "to": 8080
+          },
+          {
+            "name": "backoffice",
+            "from": 8081,
+            "to": 8081
+          }
+        ],
+        "execPreStop": [
+          "sh",
+          "-c",
+          "sleep 5 && /usr/sbin/nginx -s quit"
+        ],
+        "additionalContainers": [
+          {
+            "name": "dnsmasq",
+            "dockerImage": "nexus.mia-platform.eu/core/dnsmasq:1.0.3",
+            "defaultEnvironmentVariables": [],
+            "defaultResources": {
+              "memoryLimits": {
+                "max": "20Mi",
+                "min": "5Mi"
+              },
+              "cpuLimits": {
+                "min": "10m"
+              }
+            },
+            "args": [
+              "--listen",
+              "127.0.0.1:53",
+              "--default-resolver",
+              "--enable-search",
+              "--hostsfile=/etc/hosts"
+            ],
+            "defaultProbes": {
+              "liveness": {
+                "cmd": [
+                  "/bin/sh",
+                  "-c",
+                  "netstat -lutan | grep LISTEN | grep 53"
+                ],
+                "initialDelaySeconds": 15,
+                "periodSeconds": 20
+              },
+              "readiness": {
+                "cmd": [
+                  "/bin/sh",
+                  "-c",
+                  "netstat -lutan | grep LISTEN | grep 53"
+                ],
+                "initialDelaySeconds": 5,
+                "periodSeconds": 10
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "supportedBy": "Mia-Platform",
+  "supportedByImage": {
+    "localPath": "../../../../assets/img/mia-platform-logo-2023.png"
+  },
+  "tenantId": "mia-platform",
+  "type": "plugin",
+  "version": {
+    "name": "5.0.3",
+    "releaseNote": "Security fixes"
+  },
+  "visibility": {
+    "public": true
+  },
+  "releaseDate": "2025-02-20T16:47:48.026Z",
+  "lifecycleStatus": "published"
+}

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -2593,6 +2593,173 @@ exports[`Sync script > should match snapshot 2`] = `
           "type": "plugin",
           "name": "nginx-api-gateway",
           "description": "Use this service to route requests to the correct service and verify the need of authentication",
+          "dockerImage": "nexus.mia-platform.eu/core/api-gateway:5.0.3",
+          "componentId": "api-gateway",
+          "defaultEnvironmentVariables": [],
+          "defaultResources": {
+            "memoryLimits": {
+              "max": "25Mi",
+              "min": "5Mi"
+            },
+            "cpuLimits": {
+              "min": "10m"
+            }
+          },
+          "defaultProbes": {
+            "liveness": {
+              "port": "frontend",
+              "path": "/healthz",
+              "initialDelaySeconds": 15,
+              "periodSeconds": 20
+            },
+            "readiness": {
+              "port": "frontend",
+              "path": "/healthz",
+              "initialDelaySeconds": 5,
+              "periodSeconds": 10
+            }
+          },
+          "defaultLogParser": "mia-nginx",
+          "defaultDocumentationPath": "",
+          "defaultConfigMaps": [
+            {
+              "name": "api-gateway-server",
+              "mountPath": "/etc/nginx/conf.d",
+              "files": [],
+              "viewAsReadOnly": true
+            },
+            {
+              "name": "api-gateway-platform",
+              "mountPath": "/etc/nginx/platform.d",
+              "files": [],
+              "viewAsReadOnly": true
+            },
+            {
+              "name": "api-gateway-customization",
+              "mountPath": "/etc/nginx/customization.d",
+              "files": [],
+              "viewAsReadOnly": true,
+              "link": {
+                "targetSection": "endpoints"
+              }
+            },
+            {
+              "name": "api-gateway-backoffice",
+              "mountPath": "/etc/nginx/backoffice.d",
+              "files": [],
+              "viewAsReadOnly": true
+            }
+          ],
+          "containerPorts": [
+            {
+              "name": "frontend",
+              "from": 8080,
+              "to": 8080
+            },
+            {
+              "name": "backoffice",
+              "from": 8081,
+              "to": 8081
+            }
+          ],
+          "execPreStop": [
+            "sh",
+            "-c",
+            "sleep 5 && /usr/sbin/nginx -s quit"
+          ],
+          "additionalContainers": [
+            {
+              "name": "dnsmasq",
+              "dockerImage": "nexus.mia-platform.eu/core/dnsmasq:1.0.3",
+              "defaultEnvironmentVariables": [],
+              "defaultResources": {
+                "memoryLimits": {
+                  "max": "20Mi",
+                  "min": "5Mi"
+                },
+                "cpuLimits": {
+                  "min": "10m"
+                }
+              },
+              "args": [
+                "--listen",
+                "127.0.0.1:53",
+                "--default-resolver",
+                "--enable-search",
+                "--hostsfile=/etc/hosts"
+              ],
+              "defaultProbes": {
+                "liveness": {
+                  "cmd": [
+                    "/bin/sh",
+                    "-c",
+                    "netstat -lutan | grep LISTEN | grep 53"
+                  ],
+                  "initialDelaySeconds": 15,
+                  "periodSeconds": 20
+                },
+                "readiness": {
+                  "cmd": [
+                    "/bin/sh",
+                    "-c",
+                    "netstat -lutan | grep LISTEN | grep 53"
+                  ],
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 10
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "supportedBy": "Mia-Platform",
+    "tenantId": "mia-platform",
+    "type": "plugin",
+    "version": {
+      "name": "5.0.3",
+      "releaseNote": "Security fixes"
+    },
+    "visibility": {
+      "public": true
+    },
+    "releaseDate": "2025-02-20T16:47:48.026Z",
+    "lifecycleStatus": "published",
+    "isLatest": true,
+    "__STATE__": "PUBLIC",
+    "creatorId": "marketplace-sync",
+    "image": [
+      {
+        "name": "api-gateway_logo_20250410.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ],
+    "supportedByImage": [
+      {
+        "name": "mia-platform-logo-2023.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ]
+  },
+  {
+    "categoryId": "orchestrators",
+    "description": "Use this service to route requests to the correct service and verify the need of authentication",
+    "documentation": {
+      "type": "externalLink",
+      "url": "https://docs.mia-platform.eu/docs/runtime_suite/api-gateway/overview"
+    },
+    "itemId": "api-gateway",
+    "name": "Nginx API Gateway",
+    "publishOnMiaDocumentation": true,
+    "repositoryUrl": "https://git.tools.mia-platform.eu/platform/core/api-gateway",
+    "resources": {
+      "services": {
+        "nginx-api-gateway": {
+          "type": "plugin",
+          "name": "nginx-api-gateway",
+          "description": "Use this service to route requests to the correct service and verify the need of authentication",
           "dockerImage": "nexus.mia-platform.eu/core/api-gateway:5.0.2",
           "componentId": "api-gateway",
           "defaultEnvironmentVariables": [],
@@ -2725,7 +2892,6 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "releaseDate": "2025-02-20T16:47:48.026Z",
     "lifecycleStatus": "published",
-    "isLatest": true,
     "__STATE__": "PUBLIC",
     "creatorId": "marketplace-sync",
     "image": [


### PR DESCRIPTION
### Description

Upgrade api-gateway to 5.0.3, with dependency fixes.

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)
