### PR TITLE
feat(catalog): update Docker images to point to Mia-Platform internal registry

### DIFF
--- a/items/application/data-catalog-application/versions/NA.json
+++ b/items/application/data-catalog-application/versions/NA.json
@@ -3470,7 +3470,7 @@
             "min": "50Mi"
           }
         },
-        "dockerImage": "redis:7.2.5",
+        "dockerImage": "nexus.mia-platform.eu/cache/redis:7.2.5",
         "name": "fabric-cache",
         "tags": [
           "cache"
@@ -3518,7 +3518,7 @@
         },
         "defaultTerminationGracePeriodSeconds": 30,
         "description": "temporary UI for job-runner",
-        "dockerImage": "docker.io/fullstorydev/grpcui:v1.4.1",
+        "dockerImage": "nexus.mia-platform.eu/cache/fullstorydev/grpcui:v1.4.1",
         "name": "grpcui",
         "tags": [
           "utils"

--- a/items/application/drools-and-kie-server/versions/NA.json
+++ b/items/application/drools-and-kie-server/versions/NA.json
@@ -67,7 +67,7 @@
         "type": "plugin",
         "name": "kie-server",
         "description": "This is a ready to run Docker image for Drools KIE Server. Just run it and try the Drools runtime execution server!",
-        "dockerImage": "jboss/kie-server-showcase:latest",
+        "dockerImage": "nexus.mia-platform.eu/cache/jboss/kie-server-showcase:latest",
         "defaultEnvironmentVariables": [
           {
             "name": "HTTP_PORT",

--- a/items/application/fast-data-control-plane-with-access-control/versions/NA.json
+++ b/items/application/fast-data-control-plane-with-access-control/versions/NA.json
@@ -230,7 +230,7 @@
         "type": "plugin",
         "name": "redis-auth",
         "description": "Control Plane Redis Database employed to support authentication flow",
-        "dockerImage": "redis:7.2.5",
+        "dockerImage": "nexus.mia-platform.eu/cache/redis:7.2.5",
         "containerPorts": [
           {
             "name": "http",

--- a/items/application/fast-data-control-plane/versions/NA.json
+++ b/items/application/fast-data-control-plane/versions/NA.json
@@ -2402,7 +2402,7 @@
             "min": "50Mi"
           }
         },
-        "dockerImage": "redis:7.2.5",
+        "dockerImage": "nexus.mia-platform.eu/cache/redis:7.2.5",
         "name": "fabric-cache",
         "tags": [
           "custom"

--- a/scripts/lib/check-docker-images.ts
+++ b/scripts/lib/check-docker-images.ts
@@ -22,7 +22,6 @@ import type { ICatalogApplication } from '@mia-platform/console-types'
 import { catalogWellKnownItems } from '@mia-platform/console-types'
 import { JSONPath } from 'jsonpath-plus'
 
-import logger from './logger'
 import type { Manifest } from './utils'
 
 const NEXUS_REGISTRY_HOSTNAME = 'nexus.mia-platform.eu'
@@ -103,9 +102,7 @@ export const assertValidDockerImage = async (manifest: Manifest, nexusBasicAuth:
 
   for (const data of dockerImagesData) {
     if (!acceptedRegistries.some((registry) => data.value.startsWith(registry))) {
-      logger.warn(`Invalid Docker image at "${data.pointer}": registry must be one of "[${acceptedRegistries.join(', ')}]"`)
-      continue
-      // throw new Error(`Invalid Docker image at "${data.pointer}": registry must be "nexus.mia-platform.eu"`)
+      throw new Error(`Invalid Docker image at "${data.pointer}": registry must be "nexus.mia-platform.eu"`)
     }
 
     if (!data.value.startsWith(NEXUS_REGISTRY_HOSTNAME)) { continue }


### PR DESCRIPTION
### Description

- `redis:7.2.5`
- `docker.io/fullstorydev/grpcui:v1.4.1`
- `jboss/kie-server-showcase:latest`

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)
