### PR TITLE
feat(catalog): update all versions of appointment-manager

### DIFF
--- a/items/plugin/appointment-manager/versions/2.3.0.json
+++ b/items/plugin/appointment-manager/versions/2.3.0.json
@@ -10,6 +10,7 @@
   },
   "itemId": "appointment-manager",
   "name": "Appointment Manager",
+  "description": "Manage appointments, availabilities, slots and exceptions.",
   "publishOnMiaDocumentation": true,
   "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
   "resources": {
@@ -98,7 +99,7 @@
             "files": [
               {
                 "name": "config.json",
-                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
+                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isNotificationManagerAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
               }
             ]
           }

--- a/items/plugin/appointment-manager/versions/2.4.0.json
+++ b/items/plugin/appointment-manager/versions/2.4.0.json
@@ -10,6 +10,7 @@
   },
   "itemId": "appointment-manager",
   "name": "Appointment Manager",
+  "description": "Manage appointments, availabilities, slots and exceptions.",
   "publishOnMiaDocumentation": true,
   "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
   "resources": {
@@ -98,7 +99,7 @@
             "files": [
               {
                 "name": "config.json",
-                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false,\n\"isNotificationManagerAsync\": false\n}"
+                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isNotificationManagerAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
               }
             ]
           }

--- a/items/plugin/appointment-manager/versions/2.5.0.json
+++ b/items/plugin/appointment-manager/versions/2.5.0.json
@@ -10,6 +10,7 @@
   },
   "itemId": "appointment-manager",
   "name": "Appointment Manager",
+  "description": "Manage appointments, availabilities, slots and exceptions.",
   "publishOnMiaDocumentation": true,
   "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
   "resources": {
@@ -98,7 +99,7 @@
             "files": [
               {
                 "name": "config.json",
-                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false,\n\"isNotificationManagerAsync\": false\n}"
+                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isNotificationManagerAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
               }
             ]
           }

--- a/items/plugin/appointment-manager/versions/NA.json
+++ b/items/plugin/appointment-manager/versions/NA.json
@@ -10,6 +10,7 @@
   },
   "itemId": "appointment-manager",
   "name": "Appointment Manager",
+  "description": "Manage appointments, availabilities, slots and exceptions.",
   "publishOnMiaDocumentation": true,
   "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
   "resources": {
@@ -17,7 +18,7 @@
       "appointment-manager": {
         "type": "plugin",
         "name": "appointment-manager",
-        "dockerImage": "nexus.mia-platform.eu/plugins/appointment-manager:2.3.0",
+        "dockerImage": "nexus.mia-platform.eu/plugins/appointment-manager",
         "defaultEnvironmentVariables": [
           {
             "name": "LOG_LEVEL",
@@ -98,7 +99,7 @@
             "files": [
               {
                 "name": "config.json",
-                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
+                "content": "{\n\"users\": {},\n\"channels\": [],\n\"isTeleconsultationAvailable\": false,\n\"isMessagingAvailable\": false,\n\"isNotificationManagerAvailable\": false,\n\"isTimerAvailable\": false,\n\"isUserAvailable\": false,\n\"isFlexibleSlotAvailable\": false,\n\"isParticipantStatusAvailable\": false\n}"
               }
             ]
           }

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -4358,6 +4358,7 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "itemId": "appointment-manager",
     "name": "Appointment Manager",
+    "description": "Manage appointments, availabilities, slots and exceptions.",
     "publishOnMiaDocumentation": true,
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
     "resources": {
@@ -4446,7 +4447,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "files": [
                 {
                   "name": "config.json",
-                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false,\\n\\"isNotificationManagerAsync\\": false\\n}"
+                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isNotificationManagerAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
                 }
               ]
             }
@@ -4500,6 +4501,7 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "itemId": "appointment-manager",
     "name": "Appointment Manager",
+    "description": "Manage appointments, availabilities, slots and exceptions.",
     "publishOnMiaDocumentation": true,
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
     "resources": {
@@ -4588,7 +4590,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "files": [
                 {
                   "name": "config.json",
-                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false,\\n\\"isNotificationManagerAsync\\": false\\n}"
+                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isNotificationManagerAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
                 }
               ]
             }
@@ -4641,6 +4643,7 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "itemId": "appointment-manager",
     "name": "Appointment Manager",
+    "description": "Manage appointments, availabilities, slots and exceptions.",
     "publishOnMiaDocumentation": true,
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
     "resources": {
@@ -4729,7 +4732,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "files": [
                 {
                   "name": "config.json",
-                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
+                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isNotificationManagerAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
                 }
               ]
             }
@@ -4782,6 +4785,7 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "itemId": "appointment-manager",
     "name": "Appointment Manager",
+    "description": "Manage appointments, availabilities, slots and exceptions.",
     "publishOnMiaDocumentation": true,
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/appointment-manager",
     "resources": {
@@ -4789,7 +4793,7 @@ exports[`Sync script > should match snapshot 2`] = `
         "appointment-manager": {
           "type": "plugin",
           "name": "appointment-manager",
-          "dockerImage": "nexus.mia-platform.eu/plugins/appointment-manager:2.3.0",
+          "dockerImage": "nexus.mia-platform.eu/plugins/appointment-manager",
           "defaultEnvironmentVariables": [
             {
               "name": "LOG_LEVEL",
@@ -4870,7 +4874,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "files": [
                 {
                   "name": "config.json",
-                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
+                  "content": "{\\n\\"users\\": {},\\n\\"channels\\": [],\\n\\"isTeleconsultationAvailable\\": false,\\n\\"isMessagingAvailable\\": false,\\n\\"isNotificationManagerAvailable\\": false,\\n\\"isTimerAvailable\\": false,\\n\\"isUserAvailable\\": false,\\n\\"isFlexibleSlotAvailable\\": false,\\n\\"isParticipantStatusAvailable\\": false\\n}"
                 }
               ]
             }


### PR DESCRIPTION
### Description

Add missing description and required config map variable to all versions of the Appointment Manager (2.3.0, 2.4.0, 2.5.0).

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

Fix missing description and required config map variable