### PR TITLE
feat(catalog): update all versions of notification-manager-service

### DIFF
--- a/items/plugin/notification-manager-service/versions/2.3.0.json
+++ b/items/plugin/notification-manager-service/versions/2.3.0.json
@@ -129,7 +129,7 @@
           {
             "name": "http",
             "from": 80,
-            "to": 8080,
+            "to": 3000,
             "protocol": "TCP"
           }
         ]

--- a/items/plugin/notification-manager-service/versions/2.4.3.json
+++ b/items/plugin/notification-manager-service/versions/2.4.3.json
@@ -135,7 +135,7 @@
           {
             "name": "http",
             "from": 80,
-            "to": 8080,
+            "to": 3000,
             "protocol": "TCP"
           }
         ]

--- a/items/plugin/notification-manager-service/versions/NA.json
+++ b/items/plugin/notification-manager-service/versions/NA.json
@@ -129,7 +129,7 @@
           {
             "name": "http",
             "from": 80,
-            "to": 8080,
+            "to": 3000,
             "protocol": "TCP"
           }
         ]

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -50154,7 +50154,7 @@ exports[`Sync script > should match snapshot 2`] = `
             {
               "name": "http",
               "from": 80,
-              "to": 8080,
+              "to": 3000,
               "protocol": "TCP"
             }
           ]
@@ -50318,7 +50318,7 @@ exports[`Sync script > should match snapshot 2`] = `
             {
               "name": "http",
               "from": 80,
-              "to": 8080,
+              "to": 3000,
               "protocol": "TCP"
             }
           ]
@@ -50481,7 +50481,7 @@ exports[`Sync script > should match snapshot 2`] = `
             {
               "name": "http",
               "from": 80,
-              "to": 8080,
+              "to": 3000,
               "protocol": "TCP"
             }
           ]


### PR DESCRIPTION
### Description

Update target container port of all versions of the Notification Manager.

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

Fix target container port of all versions of the Notification Manager (from 8080 to 3000).
