### PR TITLE
feat(catalog): update version 1.0.0 of the device-manager plugin and HCP application

### DIFF
--- a/items/application/therapy-device-module/versions/NA.json
+++ b/items/application/therapy-device-module/versions/NA.json
@@ -242,15 +242,6 @@
           {
             "encryptionEnabled": false,
             "encryptionSearchable": false,
-            "name": "type",
-            "nullable": false,
-            "required": false,
-            "sensitivityValue": 0,
-            "type": "string"
-          },
-          {
-            "encryptionEnabled": false,
-            "encryptionSearchable": false,
             "name": "rawDataFormat",
             "nullable": false,
             "required": false,
@@ -384,15 +375,6 @@
             "required": false,
             "sensitivityValue": 0,
             "type": "RawObject"
-          },
-          {
-            "encryptionEnabled": false,
-            "encryptionSearchable": false,
-            "name": "canonicalForm",
-            "nullable": false,
-            "required": false,
-            "sensitivityValue": 0,
-            "type": "string"
           },
           {
             "encryptionEnabled": false,
@@ -1424,23 +1406,12 @@
             "to": 3000
           }
         ],
-        "defaultConfigMaps": [
-          {
-            "files": [
-              {
-                "content": "{\"medisante\": {\"name\": \"Medisanté\"}}",
-                "name": "config.json"
-              }
-            ],
-            "mountPath": "/home/node/app/providers/",
-            "name": "providers-config"
-          }
-        ],
+        "defaultConfigMaps": [],
         "defaultDocumentationPath": "/documentation/json",
         "defaultEnvironmentVariables": [
           {
             "name": "LOG_LEVEL",
-            "value": "trace",
+            "value": "info",
             "valueType": "plain"
           },
           {
@@ -1484,8 +1455,63 @@
             "valueType": "plain"
           },
           {
-            "name": "PROVIDERS_CONFIGURATION_PATH",
-            "value": "/home/node/app/providers/config.json",
+            "name": "CRUD_SERVICE_URL",
+            "value": "http://crud-service",
+            "valueType": "plain"
+          },
+          {
+            "name": "TMM_SERVICE_URL",
+            "value": "http://therapy-monitoring-manager",
+            "valueType": "plain"
+          },
+          {
+            "name": "CRUD_DEVICES_ENDPOINT",
+            "value": "/tdm-dm-devices",
+            "valueType": "plain"
+          },
+          {
+            "name": "CRUD_HEALTH_DATA_ENDPOINT",
+            "value": "/tdm-dm-health-data",
+            "valueType": "plain"
+          },
+          {
+            "name": "CRUD_HEALTH_DATA_TYPE_ENDPOINT",
+            "value": "/tdm-dm-health-data-type",
+            "valueType": "plain"
+          },
+          {
+            "name": "TMM_MONITORINGS_ENDPOINT",
+            "value": "/monitorings",
+            "valueType": "plain"
+          },
+          {
+            "name": "TMM_DETECTIONS_ENDPOINT",
+            "value": "/detections",
+            "valueType": "plain"
+          },
+          {
+            "name": "TMM_PROTOTYPES_ENDPOINT",
+            "value": "/prototypes",
+            "valueType": "plain"
+          },
+          {
+            "name": "MEDISANTE_PROVIDER",
+            "value": "medisante",
+            "valueType": "plain"
+          },
+          {
+            "name": "HEALTHKIT_PROVIDER",
+            "value": "healthkit",
+            "valueType": "plain"
+          },
+          {
+            "name": "STANDARD_JSON_MEDISANTE",
+            "value": "medisante-standard-json",
+            "valueType": "plain"
+          },
+          {
+            "name": "STANDARD_JSON_HEALTHKIT",
+            "value": "healthkit-standard-json",
             "valueType": "plain"
           },
           {
@@ -1531,7 +1557,7 @@
             "min": "150Mi"
           }
         },
-        "description": "A plugin to collect health data from medical and wearable devices",
+        "description": "A plugin to collect, store and visualize patient health data from medical and wearable devices",
         "dockerImage": "nexus.mia-platform.eu/mia-care/plugins/device-manager:{{DEVICE_MANAGER_VERSION}}",
         "name": "device-manager",
         "type": "plugin"

--- a/items/plugin/device-manager/versions/1.0.0.json
+++ b/items/plugin/device-manager/versions/1.0.0.json
@@ -10,6 +10,7 @@
   },
   "itemId": "device-manager",
   "name": "Device Manager",
+  "description": "Collect, store and visualize patient health data from medical and wearable devices.",
   "publishOnMiaDocumentation": true,
   "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/device-manager",
   "resources": {
@@ -131,7 +132,7 @@
           },
           {
             "name": "DATA_ACQUISITION_JOB_COLLECTION",
-            "value": "",
+            "value": "tdm_dm_data_acquisition_jobs",
             "valueType": "plain"
           }
         ],

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -23277,6 +23277,7 @@ exports[`Sync script > should match snapshot 2`] = `
     },
     "itemId": "device-manager",
     "name": "Device Manager",
+    "description": "Collect, store and visualize patient health data from medical and wearable devices.",
     "publishOnMiaDocumentation": true,
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/device-manager",
     "resources": {
@@ -23398,7 +23399,7 @@ exports[`Sync script > should match snapshot 2`] = `
             },
             {
               "name": "DATA_ACQUISITION_JOB_COLLECTION",
-              "value": "",
+              "value": "tdm_dm_data_acquisition_jobs",
               "valueType": "plain"
             }
           ],
@@ -74319,15 +74320,6 @@ exports[`Sync script > should match snapshot 2`] = `
             {
               "encryptionEnabled": false,
               "encryptionSearchable": false,
-              "name": "type",
-              "nullable": false,
-              "required": false,
-              "sensitivityValue": 0,
-              "type": "string"
-            },
-            {
-              "encryptionEnabled": false,
-              "encryptionSearchable": false,
               "name": "rawDataFormat",
               "nullable": false,
               "required": false,
@@ -74461,15 +74453,6 @@ exports[`Sync script > should match snapshot 2`] = `
               "required": false,
               "sensitivityValue": 0,
               "type": "RawObject"
-            },
-            {
-              "encryptionEnabled": false,
-              "encryptionSearchable": false,
-              "name": "canonicalForm",
-              "nullable": false,
-              "required": false,
-              "sensitivityValue": 0,
-              "type": "string"
             },
             {
               "encryptionEnabled": false,
@@ -75501,23 +75484,12 @@ exports[`Sync script > should match snapshot 2`] = `
               "to": 3000
             }
           ],
-          "defaultConfigMaps": [
-            {
-              "files": [
-                {
-                  "content": "{\\"medisante\\": {\\"name\\": \\"Medisanté\\"}}",
-                  "name": "config.json"
-                }
-              ],
-              "mountPath": "/home/node/app/providers/",
-              "name": "providers-config"
-            }
-          ],
+          "defaultConfigMaps": [],
           "defaultDocumentationPath": "/documentation/json",
           "defaultEnvironmentVariables": [
             {
               "name": "LOG_LEVEL",
-              "value": "trace",
+              "value": "info",
               "valueType": "plain"
             },
             {
@@ -75561,8 +75533,63 @@ exports[`Sync script > should match snapshot 2`] = `
               "valueType": "plain"
             },
             {
-              "name": "PROVIDERS_CONFIGURATION_PATH",
-              "value": "/home/node/app/providers/config.json",
+              "name": "CRUD_SERVICE_URL",
+              "value": "http://crud-service",
+              "valueType": "plain"
+            },
+            {
+              "name": "TMM_SERVICE_URL",
+              "value": "http://therapy-monitoring-manager",
+              "valueType": "plain"
+            },
+            {
+              "name": "CRUD_DEVICES_ENDPOINT",
+              "value": "/tdm-dm-devices",
+              "valueType": "plain"
+            },
+            {
+              "name": "CRUD_HEALTH_DATA_ENDPOINT",
+              "value": "/tdm-dm-health-data",
+              "valueType": "plain"
+            },
+            {
+              "name": "CRUD_HEALTH_DATA_TYPE_ENDPOINT",
+              "value": "/tdm-dm-health-data-type",
+              "valueType": "plain"
+            },
+            {
+              "name": "TMM_MONITORINGS_ENDPOINT",
+              "value": "/monitorings",
+              "valueType": "plain"
+            },
+            {
+              "name": "TMM_DETECTIONS_ENDPOINT",
+              "value": "/detections",
+              "valueType": "plain"
+            },
+            {
+              "name": "TMM_PROTOTYPES_ENDPOINT",
+              "value": "/prototypes",
+              "valueType": "plain"
+            },
+            {
+              "name": "MEDISANTE_PROVIDER",
+              "value": "medisante",
+              "valueType": "plain"
+            },
+            {
+              "name": "HEALTHKIT_PROVIDER",
+              "value": "healthkit",
+              "valueType": "plain"
+            },
+            {
+              "name": "STANDARD_JSON_MEDISANTE",
+              "value": "medisante-standard-json",
+              "valueType": "plain"
+            },
+            {
+              "name": "STANDARD_JSON_HEALTHKIT",
+              "value": "healthkit-standard-json",
               "valueType": "plain"
             },
             {
@@ -75608,7 +75635,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "min": "150Mi"
             }
           },
-          "description": "A plugin to collect health data from medical and wearable devices",
+          "description": "A plugin to collect, store and visualize patient health data from medical and wearable devices",
           "dockerImage": "nexus.mia-platform.eu/mia-care/plugins/device-manager:{{DEVICE_MANAGER_VERSION}}",
           "name": "device-manager",
           "type": "plugin"


### PR DESCRIPTION
### Description

Fix issues related to the Device Manager service, both as standalone plugin and as part of HCP Therapy Device Module. 

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

- Added missing plugin description
- Fixed issues with default CRUD schemas and environment variables
- Removed unused config map.