### PR TITLE
feat(catalog): update Mia Care plugins with outdated documentation

### DIFF
--- a/items/plugin/form-service-backend/versions/2.0.2.json
+++ b/items/plugin/form-service-backend/versions/2.0.2.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-backend_logo_20250410.png"
   },

--- a/items/plugin/form-service-backend/versions/2.1.1.json
+++ b/items/plugin/form-service-backend/versions/2.1.1.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-backend_logo_20250410.png"
   },

--- a/items/plugin/form-service-backend/versions/NA.json
+++ b/items/plugin/form-service-backend/versions/NA.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-backend_logo_20250410.png"
   },

--- a/items/plugin/form-service-frontend/versions/2.0.5.json
+++ b/items/plugin/form-service-frontend/versions/2.0.5.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-frontend_logo_20250410.png"
   },

--- a/items/plugin/form-service-frontend/versions/2.1.1.json
+++ b/items/plugin/form-service-frontend/versions/2.1.1.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-frontend_logo_20250410.png"
   },

--- a/items/plugin/form-service-frontend/versions/NA.json
+++ b/items/plugin/form-service-frontend/versions/NA.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/form-service-frontend_logo_20250410.png"
   },

--- a/items/plugin/pdf-service/versions/2.0.1.json
+++ b/items/plugin/pdf-service/versions/2.0.1.json
@@ -2,6 +2,11 @@
   "$schema": "../../manifest.schema.json",
   "categoryId": "utility",
   "description": "The PDF Services provides various functionalities to programmatically generate and manipulate pdf documents.",
+  "documentation": {
+    "type": "externalLink",
+    "url": "https://docs.mia-platform.eu/docs/runtime_suite/pdf-service/overview"
+  },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/pdf-service_logo_20250423.png"
   },

--- a/items/plugin/pdf-service/versions/NA.json
+++ b/items/plugin/pdf-service/versions/NA.json
@@ -2,6 +2,11 @@
   "$schema": "../../manifest.schema.json",
   "categoryId": "utility",
   "description": "The PDF Services provides various functionalities to programmatically generate and manipulate pdf documents.",
+  "documentation": {
+    "type": "externalLink",
+    "url": "https://docs.mia-platform.eu/docs/runtime_suite/pdf-service/overview"
+  },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/pdf-service_logo_20250423.png"
   },

--- a/items/plugin/user-manager-service/versions/1.5.1.json
+++ b/items/plugin/user-manager-service/versions/1.5.1.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/user-manager-service.png"
   },

--- a/items/plugin/user-manager-service/versions/1.5.2.json
+++ b/items/plugin/user-manager-service/versions/1.5.2.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/user-manager-service.png"
   },

--- a/items/plugin/user-manager-service/versions/NA.json
+++ b/items/plugin/user-manager-service/versions/NA.json
@@ -6,6 +6,7 @@
     "type": "externalLink",
     "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
   },
+  "publishOnMiaDocumentation": true,
   "image": {
     "localPath": "../assets/user-manager-service.png"
   },

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -32866,6 +32866,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-backend",
     "name": "Form Service Backend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-backend",
@@ -32925,6 +32926,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-backend",
     "name": "Form Service Backend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-backend",
@@ -32983,6 +32985,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-backend",
     "name": "Form Service Backend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-backend",
@@ -33037,6 +33040,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-frontend",
     "name": "Form Service Frontend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-frontend",
@@ -33103,6 +33107,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-frontend",
     "name": "Form Service Frontend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-frontend",
@@ -33168,6 +33173,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/form-service-backend/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "form-service-frontend",
     "name": "Form Service Frontend",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/form-service-frontend",
@@ -56643,6 +56649,11 @@ exports[`Sync script > should match snapshot 2`] = `
   {
     "categoryId": "utility",
     "description": "The PDF Services provides various functionalities to programmatically generate and manipulate pdf documents.",
+    "documentation": {
+      "type": "externalLink",
+      "url": "https://docs.mia-platform.eu/docs/runtime_suite/pdf-service/overview"
+    },
+    "publishOnMiaDocumentation": true,
     "itemId": "pdf-service",
     "name": "PDF Service",
     "repositoryUrl": "https://git.tools.mia-platform.eu/platform/plugins/pdf-service",
@@ -56717,6 +56728,11 @@ exports[`Sync script > should match snapshot 2`] = `
   {
     "categoryId": "utility",
     "description": "The PDF Services provides various functionalities to programmatically generate and manipulate pdf documents.",
+    "documentation": {
+      "type": "externalLink",
+      "url": "https://docs.mia-platform.eu/docs/runtime_suite/pdf-service/overview"
+    },
+    "publishOnMiaDocumentation": true,
     "itemId": "pdf-service",
     "name": "PDF Service",
     "repositoryUrl": "https://git.tools.mia-platform.eu/platform/plugins/pdf-service",
@@ -78480,6 +78496,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "user-manager-service",
     "name": "User Manager Service",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/user-manager-service",
@@ -78633,6 +78650,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "user-manager-service",
     "name": "User Manager Service",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/user-manager-service",
@@ -78785,6 +78803,7 @@ exports[`Sync script > should match snapshot 2`] = `
       "type": "externalLink",
       "url": "https://docs.mia-platform.eu/docs/runtime_suite/user-manager-service/overview"
     },
+    "publishOnMiaDocumentation": true,
     "itemId": "user-manager-service",
     "name": "User Manager Service",
     "repositoryUrl": "https://git.tools.mia-platform.eu/mia-care/platform/plugins/user-manager-service",


### PR DESCRIPTION
### Description

This PR adds the `publishOnMiaDocumentation` set to `true` to the following plugins maintained by Mia Care, whose documentation is already public but were missing this flag, causing the public documentation not to be updated:

- Form Service Backend
- Form Service Frontend
- PDF Service
- User Manager Service

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [ ] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

Documentation updates on several plugins were not correctly collected by the doc aggregator service.