### PR TITLE
feat(catalog): update data-catalog-application to bump job-runner to v0.2.3

### DIFF
--- a/items/application/data-catalog-application/versions/NA.json
+++ b/items/application/data-catalog-application/versions/NA.json
@@ -3654,7 +3654,7 @@
             "min": "50Mi"
           }
         },
-        "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.2",
+        "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.3",
         "name": "job-runner",
         "tags": [
           "data-fabric"

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -19846,7 +19846,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "min": "50Mi"
             }
           },
-          "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.2",
+          "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.3",
           "name": "job-runner",
           "tags": [
             "data-fabric"


### PR DESCRIPTION
### Description

Dependency data-fabric/job-runner bumped to v0.2.3

### Checklist

- [x] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [x] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

<!-- Link here any relevant issue (e.g., "Closes #XYZ") -->
