### PR TITLE
fix(sync): fixed import type and updated README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,19 @@ test-up:
 test-down:
 	docker rm -f catalog-mongo-test
 .PHONY: test-down
+
+test-mongo7-up:
+	docker run -d -p 27017:27017 --name catalog-mongo7-test mongo:7
+.PHONY: test-mongo7-up
+
+test-mongo7-down:
+	docker rm -f catalog-mongo7-test
+.PHONY: test-mongo7-down
+
+test-mongo6-up:
+	docker run -d -p 27017:27017 --name catalog-mongo6-test mongo:6
+.PHONY: test-mongo6-up
+
+test-mongo6-down:
+	docker rm -f catalog-mongo6-test
+.PHONY: test-mongo6-down

--- a/README.md
+++ b/README.md
@@ -71,3 +71,24 @@ The script accepts the following environment variables.
 | `ITEM_TYPES_FILTER`            |                                 `string`                                 |          |   All   | Comma-separated list of item types to sync.                                                                                                                       |
 | `TENANT_ID_TO_SET`             |                                 `string`                                 |    ✔     |         | Identifier of the Mia-Platform [company](https://docs.mia-platform.eu/docs/console/company-configuration/overview) to set as `tenantId` property of synced items. |
 | `DOCKER_IMAGE_REGISTRY_TO_SET` |                                 `string`                                 |          |         | Docker registry URL to set as `dockerImage` property of synced items.                                                                                             |
+| `CONFIG_MAP_ABSOLUTE_PATH`     |                                 `string`                                 |          |         | Absolute path to ConfigMap file containing a list of filters to fully customize `dockerImage`.|
+
+#### Docker image full customization
+
+The feature to fully customize each `dockerImage` based on regex expressions works providing a valid link to json file through this env `CONFIG_MAP_ABSOLUTE_PATH`.\
+The file inside must be in json format with a list of regex filters followed by their respective replace, below can be found a simple example.
+
+##### Example
+
+```json
+{
+  "dockerImageFilterList": [
+    {
+      "filter": "nexus.mia-platform.eu/cache/(.*)",
+      "replace": "my-registry-cache.com/$1"
+    },
+  ]
+}
+```
+
+More structured specifications can be found in the json schema in `src/filters.schema.json` that is used by the script to validate the json provided at startup.

--- a/default.env
+++ b/default.env
@@ -1,8 +1,0 @@
-LOG_LEVEL=debug
-MONGODB_URL=mongodb://localhost:27017/catalog
-FILES_SERVICE_URL=http://files-service/
-CATEGORIES_COLLECTION_NAME=categories
-ITEMS_COLLECTION_NAME=items
-FILES_COLLECTION_NAME=files
-DOCKER_IMAGE_REGISTRY_TO_SET=my-docker-registry
-TENANT_ID_TO_SET=my-tenant-id

--- a/src/lib/override-items-fields.ts
+++ b/src/lib/override-items-fields.ts
@@ -44,9 +44,8 @@ export const getCustomFilters = async (ctx: SyncCtx): Promise<CustomFilters | un
   // Load the custom filters from the JSON file
   ctx.logger.info(`Loading custom filters from: ${ctx.env.CONFIG_MAP_ABSOLUTE_PATH}`)
   try {
-    // const importedJsonFilters = await import(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, { with: { type: 'json' } }) as { default: CustomFilters }
-    const importedJsonFiltersRaw = fs.readFile(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, 'utf-8')
-    const customFilters = JSON.parse(await importedJsonFiltersRaw) as CustomFilters
+    const importedJsonFiltersRaw = await fs.readFile(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, 'utf-8')
+    const customFilters = JSON.parse(importedJsonFiltersRaw) as CustomFilters
     const validationResult = validateJsonWithSchema(customFilters, jsonSchema)
     if (!validationResult.valid) {
       ctx.logger.error(`Custom filters validation failed: ${JSON.stringify(validationResult.errors)}`)

--- a/src/lib/override-items-fields.ts
+++ b/src/lib/override-items-fields.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import fs from 'node:fs/promises'
+
 import Ajv from 'ajv'
 
 import jsonSchema from '../filters.schema.json' with { type: 'json' }
@@ -42,8 +44,9 @@ export const getCustomFilters = async (ctx: SyncCtx): Promise<CustomFilters | un
   // Load the custom filters from the JSON file
   ctx.logger.info(`Loading custom filters from: ${ctx.env.CONFIG_MAP_ABSOLUTE_PATH}`)
   try {
-    const importedJsonFilters = await import(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, { with: { type: 'json' } }) as { default: CustomFilters }
-    const customFilters = importedJsonFilters.default
+    // const importedJsonFilters = await import(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, { with: { type: 'json' } }) as { default: CustomFilters }
+    const importedJsonFiltersRaw = fs.readFile(ctx.env.CONFIG_MAP_ABSOLUTE_PATH, 'utf-8')
+    const customFilters = JSON.parse(await importedJsonFiltersRaw) as CustomFilters
     const validationResult = validateJsonWithSchema(customFilters, jsonSchema)
     if (!validationResult.valid) {
       ctx.logger.error(`Custom filters validation failed: ${JSON.stringify(validationResult.errors)}`)


### PR DESCRIPTION
### Description

- updated README.md
- removed unused default
- updated makefile with more mongoDB versions

### Checklist

- [x] Changes are covered by tests.
- [x] Any new `.js` or `.ts` file includes the Apache 2.0 License disclaimer heading.
- [x] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#work-with-the-sync-script).

### Addressed issue

fixed json filter file import using fs
