### PR TITLE
feat(catalog): update job-runner version of application data-catalog-application

### DIFF
--- a/items/application/data-catalog-application/versions/NA.json
+++ b/items/application/data-catalog-application/versions/NA.json
@@ -3654,7 +3654,7 @@
             "min": "50Mi"
           }
         },
-        "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.3",
+        "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.5",
         "name": "job-runner",
         "tags": [
           "data-fabric"

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -20455,7 +20455,7 @@ exports[`Sync script > should match snapshot 2`] = `
               "min": "50Mi"
             }
           },
-          "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.3",
+          "dockerImage": "nexus.mia-platform.eu/data-fabric/job-runner:0.2.5",
           "name": "job-runner",
           "tags": [
             "data-fabric"


### PR DESCRIPTION
### Description

Update `data-catalog-application` to include the latest version of the `job-runner`.

### Checklist

- [X] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [X] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [X] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

### Addressed issue

<!-- Link here any relevant issue (e.g., "Closes #XYZ") -->
