### PR TITLE
feat(catalog): add version 0.4.1 to plugin data-fabric-mongezium-cdc

### DIFF
--- a/items/plugin/data-fabric-mongezium-cdc/versions/0.4.1.json
+++ b/items/plugin/data-fabric-mongezium-cdc/versions/0.4.1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "../../manifest.schema.json",
+  "categoryId": "fast-data",
+  "description": "A CDC (Change Data Capture) plugin from MongoDB to Kafka, enabling real-time data synchronization of database collection events",
+  "documentation": {
+    "type": "externalLink",
+    "url": "https://docs.mia-platform.eu/docs/runtime_suite/mongezium-cdc/overview"
+  },
+  "image": {
+    "localPath": "../assets/mongezium_logo_20250708.png"
+  },
+  "itemId": "data-fabric-mongezium-cdc",
+  "name": "Mongezium CDC",
+  "repositoryUrl": "https://git.tools.mia-platform.eu/platform/data-fabric/mongezium",
+  "resources": {
+    "services": {
+      "mongezium-cdc": {
+        "type": "plugin",
+        "name": "data-fabric-mongezium-cdc",
+        "dockerImage": "nexus.mia-platform.eu/data-fabric/mongezium:0.4.1",
+        "defaultResources": {
+          "cpuLimits": {
+            "max": "300m",
+            "min": "50m"
+          },
+          "memoryLimits": {
+            "max": "300Mi",
+            "min": "50Mi"
+          }
+        },
+        "defaultProbes": {
+          "liveness": {
+            "path": "/-/healthz",
+            "port": "http",
+            "initialDelaySeconds": 5,
+            "periodSeconds": 20,
+            "timeoutSeconds": 3,
+            "failureThreshold": 3
+          },
+          "readiness": {
+            "path": "/-/ready",
+            "port": "http",
+            "initialDelaySeconds": 5,
+            "periodSeconds": 20,
+            "timeoutSeconds": 3,
+            "successThreshold": 1,
+            "failureThreshold": 3
+          },
+          "startup": {}
+        },
+        "defaultEnvironmentVariables": [
+          {
+            "name": "LOG_LEVEL",
+            "valueType": "plain",
+            "value": "info"
+          }
+        ],
+        "defaultConfigMaps": [
+          {
+            "name": "mongezium-cdc-configuration",
+            "mountPath": "/home/mongezium/.df/mongezium",
+            "files": [
+              {
+                "content": "{\n  \"persistence\": {\n    \"url\": \"CHANGE_ME\"\n  },\n  \"collections\": [],\n  \"stream\": {\n    \"consumer\": {\n      \"bootstrap.servers\": \"CHANGE_ME\"\n    },\n    \"producer\": {\n      \"bootstrap.servers\": \"CHANGE_ME\"\n    }\n  }\n}\n",
+                "name": "config.json"
+              }
+            ]
+          }
+        ],
+        "containerPorts": [
+          {
+            "name": "http",
+            "to": 3000,
+            "from": 80,
+            "protocol": "TCP"
+          }
+        ]
+      }
+    }
+  },
+  "supportedBy": "Mia-Platform",
+  "supportedByImage": {
+    "localPath": "../../../../assets/img/mia-platform-logo-2023.png"
+  },
+  "tenantId": "mia-platform",
+  "visibility": {
+    "public": true
+  },
+  "releaseDate": "2025-09-22T15:07:08.407Z",
+  "lifecycleStatus": "published",
+  "version": {
+    "name": "0.4.1",
+    "releaseNote": "## What's Changed\n* improved status probe startup behavior\n*add the possibility to customize application name for MongoDB driver\n"
+  },
+  "itemTypeDefinitionRef": {
+    "name": "plugin",
+    "namespace": "mia-platform"
+  }
+}

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -20743,6 +20743,115 @@ exports[`Sync script > should match snapshot 2`] = `
         "mongezium-cdc": {
           "type": "plugin",
           "name": "data-fabric-mongezium-cdc",
+          "dockerImage": "nexus.mia-platform.eu/data-fabric/mongezium:0.4.1",
+          "defaultResources": {
+            "cpuLimits": {
+              "max": "300m",
+              "min": "50m"
+            },
+            "memoryLimits": {
+              "max": "300Mi",
+              "min": "50Mi"
+            }
+          },
+          "defaultProbes": {
+            "liveness": {
+              "path": "/-/healthz",
+              "port": "http",
+              "initialDelaySeconds": 5,
+              "periodSeconds": 20,
+              "timeoutSeconds": 3,
+              "failureThreshold": 3
+            },
+            "readiness": {
+              "path": "/-/ready",
+              "port": "http",
+              "initialDelaySeconds": 5,
+              "periodSeconds": 20,
+              "timeoutSeconds": 3,
+              "successThreshold": 1,
+              "failureThreshold": 3
+            },
+            "startup": {}
+          },
+          "defaultEnvironmentVariables": [
+            {
+              "name": "LOG_LEVEL",
+              "valueType": "plain",
+              "value": "info"
+            }
+          ],
+          "defaultConfigMaps": [
+            {
+              "name": "mongezium-cdc-configuration",
+              "mountPath": "/home/mongezium/.df/mongezium",
+              "files": [
+                {
+                  "content": "{\\n  \\"persistence\\": {\\n    \\"url\\": \\"CHANGE_ME\\"\\n  },\\n  \\"collections\\": [],\\n  \\"stream\\": {\\n    \\"consumer\\": {\\n      \\"bootstrap.servers\\": \\"CHANGE_ME\\"\\n    },\\n    \\"producer\\": {\\n      \\"bootstrap.servers\\": \\"CHANGE_ME\\"\\n    }\\n  }\\n}\\n",
+                  "name": "config.json"
+                }
+              ]
+            }
+          ],
+          "containerPorts": [
+            {
+              "name": "http",
+              "to": 3000,
+              "from": 80,
+              "protocol": "TCP"
+            }
+          ]
+        }
+      }
+    },
+    "supportedBy": "Mia-Platform",
+    "tenantId": "mia-platform",
+    "visibility": {
+      "public": true
+    },
+    "releaseDate": "2025-09-22T15:07:08.407Z",
+    "lifecycleStatus": "published",
+    "version": {
+      "name": "0.4.1",
+      "releaseNote": "## What's Changed\\n* improved status probe startup behavior\\n*add the possibility to customize application name for MongoDB driver\\n"
+    },
+    "itemTypeDefinitionRef": {
+      "name": "plugin",
+      "namespace": "mia-platform"
+    },
+    "isLatest": true,
+    "__STATE__": "PUBLIC",
+    "creatorId": "marketplace-sync",
+    "image": [
+      {
+        "name": "mongezium_logo_20250708.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ],
+    "supportedByImage": [
+      {
+        "name": "mia-platform-logo-2023.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ]
+  },
+  {
+    "categoryId": "fast-data",
+    "description": "A CDC (Change Data Capture) plugin from MongoDB to Kafka, enabling real-time data synchronization of database collection events",
+    "documentation": {
+      "type": "externalLink",
+      "url": "https://docs.mia-platform.eu/docs/runtime_suite/mongezium-cdc/overview"
+    },
+    "itemId": "data-fabric-mongezium-cdc",
+    "name": "Mongezium CDC",
+    "repositoryUrl": "https://git.tools.mia-platform.eu/platform/data-fabric/mongezium",
+    "resources": {
+      "services": {
+        "mongezium-cdc": {
+          "type": "plugin",
+          "name": "data-fabric-mongezium-cdc",
           "dockerImage": "nexus.mia-platform.eu/data-fabric/mongezium:0.4.0",
           "defaultResources": {
             "cpuLimits": {
@@ -20819,7 +20928,6 @@ exports[`Sync script > should match snapshot 2`] = `
       "name": "plugin",
       "namespace": "mia-platform"
     },
-    "isLatest": true,
     "__STATE__": "PUBLIC",
     "creatorId": "marketplace-sync",
     "image": [


### PR DESCRIPTION
### Description

Add version `0.4.1` to `data-fabric-mongezium-cdc`

### Checklist

- [X] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [X] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [X] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)

