### PR TITLE
feat(catalog): add version 7.2.5 to plugin crud-service

### DIFF
--- a/items/plugin/crud-service/versions/7.2.5.json
+++ b/items/plugin/crud-service/versions/7.2.5.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "../../manifest.schema.json",
+  "categoryId": "database",
+  "description": "Use Mia-Platform core Crud Service to manage different instances of the service.",
+  "documentation": {
+    "type": "externalLink",
+    "url": "https://docs.mia-platform.eu/docs/runtime_suite/crud-service/overview_and_usage"
+  },
+  "image": {
+    "localPath": "../assets/crud-service_logo_20250410.png"
+  },
+  "itemId": "crud-service",
+  "name": "CRUD Service",
+  "repositoryUrl": "https://github.com/mia-platform/crud-service",
+  "resources": {
+    "services": {
+      "crud-service": {
+        "type": "plugin",
+        "name": "crud-service",
+        "description": "Use Mia-Platform core Crud Service to manage different instances of the service.",
+        "dockerImage": "nexus.mia-platform.eu/core/crud-service:7.2.5",
+        "componentId": "crud-service",
+        "mapEnvVarToMountPath": {
+          "collections": {
+            "type": "folder",
+            "envName": "COLLECTION_DEFINITION_FOLDER"
+          }
+        },
+        "defaultEnvironmentVariables": [
+          {
+            "name": "LOG_LEVEL",
+            "value": "{{LOG_LEVEL}}",
+            "valueType": "plain"
+          },
+          {
+            "name": "HTTP_PORT",
+            "value": "3000",
+            "valueType": "plain"
+          },
+          {
+            "name": "COLLECTION_DEFINITION_FOLDER",
+            "value": "/home/node/app/collections",
+            "valueType": "plain"
+          },
+          {
+            "name": "USER_ID_HEADER_KEY",
+            "value": "miauserid",
+            "valueType": "plain"
+          },
+          {
+            "name": "TRUSTED_PROXIES",
+            "value": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+            "valueType": "plain"
+          },
+          {
+            "name": "CRUD_LIMIT_CONSTRAINT_ENABLED",
+            "value": "{{CRUD_LIMIT_CONSTRAINT_ENABLED}}",
+            "valueType": "plain"
+          },
+          {
+            "name": "EXPOSE_METRICS",
+            "value": "false",
+            "valueType": "plain"
+          },
+          {
+            "name": "MONGODB_URL",
+            "value": "{{MONGODB_URL}}",
+            "valueType": "plain"
+          }
+        ],
+        "defaultResources": {
+          "memoryLimits": {
+            "max": "300Mi",
+            "min": "70Mi"
+          },
+          "cpuLimits": {
+            "max": "400m",
+            "min": "100m"
+          }
+        },
+        "defaultConfigMaps": [
+          {
+            "name": "crud-service-collections",
+            "mountPath": "/home/node/app/collections",
+            "files": [],
+            "viewAsReadOnly": true,
+            "link": {
+              "targetSection": "collections"
+            }
+          }
+        ],
+        "containerPorts": [
+          {
+            "name": "http",
+            "from": 80,
+            "to": 3000,
+            "protocol": "TCP"
+          }
+        ]
+      }
+    }
+  },
+  "supportedBy": "Mia-Platform",
+  "supportedByImage": {
+    "localPath": "../../../../assets/img/mia-platform-logo-2023.png"
+  },
+  "tenantId": "mia-platform",
+  "version": {
+    "name": "7.2.5",
+    "releaseNote": "## What's Changed\n* fix: add FASTIFY_PLUGIN_TIMEOUT_MS environment variable to allow customizing the timeout value. This helps to relieve startup issues in case many collections are managed by crud-service."
+  },
+  "visibility": {
+    "public": true
+  },
+  "releaseDate": "2025-04-03T13:02:52.025Z",
+  "lifecycleStatus": "published",
+  "itemTypeDefinitionRef": {
+    "name": "plugin",
+    "namespace": "mia-platform"
+  }
+}

--- a/tests/integration.test.ts.snapshot
+++ b/tests/integration.test.ts.snapshot
@@ -14292,6 +14292,137 @@ exports[`Sync script > should match snapshot 2`] = `
           "type": "plugin",
           "name": "crud-service",
           "description": "Use Mia-Platform core Crud Service to manage different instances of the service.",
+          "dockerImage": "nexus.mia-platform.eu/core/crud-service:7.2.5",
+          "componentId": "crud-service",
+          "mapEnvVarToMountPath": {
+            "collections": {
+              "type": "folder",
+              "envName": "COLLECTION_DEFINITION_FOLDER"
+            }
+          },
+          "defaultEnvironmentVariables": [
+            {
+              "name": "LOG_LEVEL",
+              "value": "{{LOG_LEVEL}}",
+              "valueType": "plain"
+            },
+            {
+              "name": "HTTP_PORT",
+              "value": "3000",
+              "valueType": "plain"
+            },
+            {
+              "name": "COLLECTION_DEFINITION_FOLDER",
+              "value": "/home/node/app/collections",
+              "valueType": "plain"
+            },
+            {
+              "name": "USER_ID_HEADER_KEY",
+              "value": "miauserid",
+              "valueType": "plain"
+            },
+            {
+              "name": "TRUSTED_PROXIES",
+              "value": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+              "valueType": "plain"
+            },
+            {
+              "name": "CRUD_LIMIT_CONSTRAINT_ENABLED",
+              "value": "{{CRUD_LIMIT_CONSTRAINT_ENABLED}}",
+              "valueType": "plain"
+            },
+            {
+              "name": "EXPOSE_METRICS",
+              "value": "false",
+              "valueType": "plain"
+            },
+            {
+              "name": "MONGODB_URL",
+              "value": "{{MONGODB_URL}}",
+              "valueType": "plain"
+            }
+          ],
+          "defaultResources": {
+            "memoryLimits": {
+              "max": "300Mi",
+              "min": "70Mi"
+            },
+            "cpuLimits": {
+              "max": "400m",
+              "min": "100m"
+            }
+          },
+          "defaultConfigMaps": [
+            {
+              "name": "crud-service-collections",
+              "mountPath": "/home/node/app/collections",
+              "files": [],
+              "viewAsReadOnly": true,
+              "link": {
+                "targetSection": "collections"
+              }
+            }
+          ],
+          "containerPorts": [
+            {
+              "name": "http",
+              "from": 80,
+              "to": 3000,
+              "protocol": "TCP"
+            }
+          ]
+        }
+      }
+    },
+    "supportedBy": "Mia-Platform",
+    "tenantId": "mia-platform",
+    "version": {
+      "name": "7.2.5",
+      "releaseNote": "## What's Changed\\n* fix: add FASTIFY_PLUGIN_TIMEOUT_MS environment variable to allow customizing the timeout value. This helps to relieve startup issues in case many collections are managed by crud-service."
+    },
+    "visibility": {
+      "public": true
+    },
+    "releaseDate": "2025-04-03T13:02:52.025Z",
+    "lifecycleStatus": "published",
+    "itemTypeDefinitionRef": {
+      "name": "plugin",
+      "namespace": "mia-platform"
+    },
+    "isLatest": true,
+    "__STATE__": "PUBLIC",
+    "creatorId": "marketplace-sync",
+    "image": [
+      {
+        "name": "crud-service_logo_20250410.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ],
+    "supportedByImage": [
+      {
+        "name": "mia-platform-logo-2023.png",
+        "creatorId": "marketplace-sync",
+        "updaterId": "marketplace-sync"
+      }
+    ]
+  },
+  {
+    "categoryId": "database",
+    "description": "Use Mia-Platform core Crud Service to manage different instances of the service.",
+    "documentation": {
+      "type": "externalLink",
+      "url": "https://docs.mia-platform.eu/docs/runtime_suite/crud-service/overview_and_usage"
+    },
+    "itemId": "crud-service",
+    "name": "CRUD Service",
+    "repositoryUrl": "https://github.com/mia-platform/crud-service",
+    "resources": {
+      "services": {
+        "crud-service": {
+          "type": "plugin",
+          "name": "crud-service",
+          "description": "Use Mia-Platform core Crud Service to manage different instances of the service.",
           "dockerImage": "nexus.mia-platform.eu/core/crud-service:7.2.4",
           "componentId": "crud-service",
           "mapEnvVarToMountPath": {
@@ -14389,7 +14520,6 @@ exports[`Sync script > should match snapshot 2`] = `
       "name": "plugin",
       "namespace": "mia-platform"
     },
-    "isLatest": true,
     "__STATE__": "PUBLIC",
     "creatorId": "marketplace-sync",
     "image": [


### PR DESCRIPTION
### Description

<!-- Provide a brief description of your changes -->

Introduce version v7.2.5 of CRUD Service.

### Checklist

- [X] Changes made to the Catalog are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#rules--conventions).
- [X] Pull request title and label(s) are compliant with the [contributing guidelines](https://github.com/mia-platform-marketplace/public-catalog/blob/main/CONTRIBUTING.md#common-operations).
- [X] You have regenerated the snapshots running `yarn test:snapshot` (you can spin up the needed MongoDB instance with `make test-up`, and stop it with `make test-down`)
